### PR TITLE
ジャンル作成時バリデーション判定を行う

### DIFF
--- a/app/controllers/genres_controller.rb
+++ b/app/controllers/genres_controller.rb
@@ -6,8 +6,12 @@ class GenresController < ApplicationController
   end
 
   def create
-    Genre.create(genre_params)
-    genres_all
+    genre = Genre.new(genre_params)
+    if genre.save
+      genres_all
+    else
+      render status: 422, json: genre.errors.full_messages
+    end
   end
 
   def destroy

--- a/app/controllers/genres_controller.rb
+++ b/app/controllers/genres_controller.rb
@@ -6,6 +6,8 @@ class GenresController < ApplicationController
   end
 
   def create
+    # 保存に失敗した場合フロントでエラーメッセージを表示させる。
+    # 日本語化は後々やる
     genre = Genre.new(genre_params)
     if genre.save
       genres_all
@@ -15,6 +17,7 @@ class GenresController < ApplicationController
   end
 
   def destroy
+    # 削除に失敗した場合の挙動はフロントでハンドリングする
     @genre.destroy
     genres_all
   end

--- a/app/models/genre.rb
+++ b/app/models/genre.rb
@@ -1,3 +1,4 @@
 class Genre < ApplicationRecord
   has_many :tasks, dependent: :destroy
+  validates :name, presence: true
 end


### PR DESCRIPTION
# 実装概要
- genreモデルにnameが必須であるバリデーションを追加
- genres_controllerのcreateアクションでバリデーションによるハンドリングを実装

# 実装の目的
- 空のジャンルデータが保存されないようにするため
- カラムが増えた場合などにサーバーサイドでハンドリングしておくほうが拡張性が高いため
- フロントのハンドリングだけでは悪意あるユーザーのリクエストに対処できないため

# ユーザーストーリー
1. ユーザーがジャンルモーダルを開く
2. 入力内容を空にして送信
3. エラーメッセージが表示される

# issue
なし

# 動作確認
- ジャンルモーダルで名前を入力せずに送信するとエラーメッセージが表示される
![画面収録-2021-07-31-10 54 05](https://user-images.githubusercontent.com/64336740/127725993-7edb772e-a4f2-435c-9e80-6318347a1687.gif)

# その他
日本語化は後日やる

# プルリク提出時の確認事項
下記全てにチェック（x）をつけてから提出しましょう。

## コーディングの品質向上
- [x] **1.コメント**：初心者エンジニアにも分かりやすいような、相手目線でのコメントを書いた。
- [x] **2.テスト**：ユースケースが追加/変更された場合は、それに対して変更に強いテストを書いた。

## プルリクの品質向上
- [x] **3.UI のキャプチャ**：UI に変更がある場合は、変更点が分かりやすく伝わるように、キャプチャを貼っている。
